### PR TITLE
Upstreaming Frederik's MutatorScale edits from ScaleFast

### DIFF
--- a/lib/mutatorScale/objects/mathGlyph.py
+++ b/lib/mutatorScale/objects/mathGlyph.py
@@ -1,11 +1,13 @@
 import weakref
 
 from fontParts.fontshell import RGlyph
+from fontParts.base import BaseGlyph
+
 try: # RF >= 3.3b
     from fontTools.pens.pointPen import BasePointToSegmentPen, AbstractPointPen, PointToSegmentPen
 except:
     from ufoLib.pointPen import BasePointToSegmentPen, AbstractPointPen, PointToSegmentPen
-from fontParts.base import BaseGlyph
+
 from math import radians, tan, cos, sin, pi
 
 '''

--- a/lib/mutatorScale/objects/scaler.py
+++ b/lib/mutatorScale/objects/scaler.py
@@ -197,7 +197,7 @@ class MutatorScaleEngine:
 
     def getScaledGlyph(self, glyphName, stemTarget, slantCorrection=True, attributes=None):
         """Return an interpolated & scaled glyph according to set parameters and given masters."""
-        masters = self.masters.values()
+        masters = list(self.masters.values())
         workingStems = self._workingStems
         mutatorMasters = []
         yScales = []
@@ -297,7 +297,7 @@ class MutatorScaleEngine:
                 instance = m.makeInstance(location)
                 return instance
         except Exception as e:
-            self.mutatorErrors.append({'error':e.message})
+            self.mutatorErrors.append({'error':e})
             return None
 
     def _getTargetLocation(self, stemTarget, masters, workingStems, scale):

--- a/lib/mutatorScale/pens/utilityPens.py
+++ b/lib/mutatorScale/pens/utilityPens.py
@@ -1,10 +1,12 @@
 #coding=utf-8
 from fontTools.pens.basePen import BasePen
+
 try: # RF >= 3.3b
     from fontTools.pens.pointPen import AbstractPointPen
 except:
     from ufoLib.pointPen import AbstractPointPen
 
+ 
 class ClockwiseTestPointPen(AbstractPointPen):
 
     def __init__(self):

--- a/lib/mutatorScale/utilities/fontUtils.py
+++ b/lib/mutatorScale/utilities/fontUtils.py
@@ -121,7 +121,9 @@ def freezeGlyph(glyph):
 
     toRFGlyph = RGlyph()
     toRFpen = toRFGlyph.getPen()
-    glyph.draw(toRFpen)
+    # draw only the contours, decomposed components will be added later on
+    for contour in glyph:
+        contour.draw(toRFpen)
 
     if len(glyph.components):
         decomposedComponents = extractComposites(glyph)


### PR DESCRIPTION
Reconciling differences between this MutatorScale and the MutatorScale inside of ScaleFast, which is newer... Slight differences in formatting only, except in `fontUtils.py`, where there was an edit to only draw contours at first.